### PR TITLE
Remove img from table elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ Inky.prototype = {
   // Returns:
   //    boolean: true/false
   isTableElement: function(elType) {
-    var tableEls = ['td', 'tr', 'table', 'center', 'tbody', 'img'];
+    var tableEls = ['td', 'tr', 'th', 'table', 'center', 'tbody'];
 
     // if the element is an element that comes with td
     if (tableEls.indexOf(elType) > -1) {


### PR DESCRIPTION
When having columns (example: `<columns small='12' large='12'><img/></columns>`) with img tags in them, invalid markup is generated `<table><img/></table>` instead of `<table><tr><td><img/></td></tr></table>`. It is unclear first place why img should be in there. I also added th in case custom th elements are used.