### PR TITLE
Add new spacer component 

### DIFF
--- a/lib/componentFactory.js
+++ b/lib/componentFactory.js
@@ -118,7 +118,7 @@ module.exports = function(element) {
         size = (element.attr('size'));
       }
 
-      return format('<table class="%s"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;mso-line-height-rule: exactly;line-height:'+size+'px;">&nbsp;</td></tr></tbody></table>', classes.join(' '), inner);
+      return format('<table class="%s"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&#xA0;</td></tr></tbody></table>', classes.join(' '), inner);
 
     default:
       // If it's not a custom component, return it as-is

--- a/lib/componentFactory.js
+++ b/lib/componentFactory.js
@@ -107,6 +107,19 @@ module.exports = function(element) {
 
       return format('<table class="callout"><tr><th class="%s">%s</th><th class="expander"></th></tr></table>', classes.join(' '), inner);
 
+    // <spacer>
+    case this.components.spacer:
+      var classes = ['spacer'];
+      var size = 16;
+      if (element.attr('class')) {
+        classes = classes.concat(element.attr('class').split(' '));
+      }
+      if (element.attr('size')) {
+        size = (element.attr('size'));
+      }
+
+      return format('<table class="%s"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;mso-line-height-rule: exactly;line-height:'+size+'px;">&nbsp;</td></tr></tbody></table>', classes.join(' '), inner);
+
     default:
       // If it's not a custom component, return it as-is
       return format('<tr><td>%s</td></tr>', $.html(element));

--- a/lib/inky.js
+++ b/lib/inky.js
@@ -22,7 +22,8 @@ function Inky(options) {
     blockGrid: 'block-grid',
     menu: 'menu',
     menuItem: 'item',
-    center: 'center'
+    center: 'center',
+    spacer: 'spacer'
   }, options.components || {});
 
   // Column count for grid

--- a/test/components.js
+++ b/test/components.js
@@ -229,3 +229,35 @@ describe('Callout', () => {
     compare(input, expected);
   });
 });
+  
+describe('Spacer', () => {
+  it('creates a spacer element with correct size', () => {
+    var input = '<spacer size="10"></spacer>';
+    var expected = `
+      <table class="spacer">
+        <tbody>
+          <tr>
+            <td height="10px" style="font-size:10px;line-height:10px;">&#xA0;</td>
+          </tr>
+        </tbody>
+      </table>
+    `;
+
+    compare(input, expected);
+  });
+  
+  it('copies classes to the final spacer HTML', () => {
+    var input = '<spacer size="10" class="bgcolor"></spacer>';
+    var expected = `
+      <table class="spacer bgcolor">
+        <tbody>
+          <tr>
+            <td height="10px" style="font-size:10px;line-height:10px;">&#xA0;</td>
+          </tr>
+        </tbody>
+      </table>
+    `;
+
+    compare(input, expected);
+  });
+});


### PR DESCRIPTION
Suggesting a component used for accurate vertical spacing.

It would be used that way :  `<spacer size="10"></spacer>` and generates a battle-tested 
`<table class="spacer"><tbody><tr><td height="10px" style="font-size:10px;mso-line-height-rule: exactly;line-height:10px;">&nbsp;</td></tr></tbody></table>`

I feel this kind of component can be helpful in the framework because it allows an easy way of managing padding/margins without ever using them (usually unreliable on outlook). For instance it's very nice to make separations between blocks (even with different background colors), or even between elements in a single column.

I will make a pr to the foundation for emails repo because a css rule is also needed (100% width)