### PR TITLE
Added data-attribute no-expander to <columns> to disable the .expander

### DIFF
--- a/lib/makeColumn.js
+++ b/lib/makeColumn.js
@@ -39,7 +39,7 @@ module.exports = function(col) {
 
   // If the column contains a nested row, the .expander class should not be used
   // The == on the first check is because we're comparing a string pulled from $.attr() to a number
-  if (largeSize == this.columnCount && col.find('.row, row').length === 0 && noExpander == undefined  ) {
+  if (largeSize == this.columnCount && col.find('.row, row').length === 0 && (noExpander == undefined || noExpander == "false") ) {
     expander = '\n<th class="expander"></th>';
   }
 

--- a/lib/makeColumn.js
+++ b/lib/makeColumn.js
@@ -25,6 +25,7 @@ module.exports = function(col) {
   // Check for sizes. If no attribute is provided, default to small-12. Divide evenly for large columns
   var smallSize = $(col).attr('small') || this.columnCount;
   var largeSize = $(col).attr('large') || $(col).attr('small') || Math.floor(this.columnCount / colCount);
+  var noExpander =  $(col).attr('no-expander');
 
   classes.push(format('small-%s', smallSize));
   classes.push(format('large-%s', largeSize));
@@ -38,7 +39,7 @@ module.exports = function(col) {
 
   // If the column contains a nested row, the .expander class should not be used
   // The == on the first check is because we're comparing a string pulled from $.attr() to a number
-  if (largeSize == this.columnCount && col.find('.row, row').length === 0) {
+  if (largeSize == this.columnCount && col.find('.row, row').length === 0 && noExpander == undefined  ) {
     expander = '\n<th class="expander"></th>';
   }
 

--- a/test/grid.js
+++ b/test/grid.js
@@ -75,6 +75,52 @@ describe('Grid', () => {
     compare(input, expected);
   });
 
+  it('creates a single column with first and last classes with no-expander', function () {
+    var input = '<columns large="12" small="12" no-expander>One</columns>';
+    var expected = `
+      <th class="small-12 large-12 columns first last">
+        <table>
+          <tr>
+            <th>One</th>
+          </tr>
+        </table>
+      </th>
+    `;
+
+  compare(input, expected);
+  });
+
+  it('creates a single column with first and last classes with no-expander="false"', function () {
+    var input = '<columns large="12" small="12" no-expander="false">One</columns>';
+    var expected = `
+      <th class="small-12 large-12 columns first last">
+        <table>
+          <tr>
+            <th>One</th>
+            <th class="expander"></th>
+          </tr>
+        </table>
+      </th>
+    `;
+
+  compare(input, expected);
+  });
+
+  it('creates a single column with first and last classes with no-expander="true"', function () {
+    var input = '<columns large="12" small="12" no-expander="true">One</columns>';
+    var expected = `
+      <th class="small-12 large-12 columns first last">
+        <table>
+          <tr>
+            <th>One</th>
+          </tr>
+        </table>
+      </th>
+    `;
+
+  compare(input, expected);
+  });
+
   it('creates two columns, one first, one last', function () {
     var input = `
       <columns large="6" small="12">One</columns>


### PR DESCRIPTION
Added data-attribute no-expander to <columns> to disable the .expander.

**Reason of adding:** 
To disable adding th.expander on a column when it has 12 size. 
It breaks the full width images in the emails in MS outlook & MS live, setting the width of the cell 50%.

With this edit, you can disable the expander, by adding no-expander to <columns> 
Example: 
`<columns large="12" small="12" no-expander>One</columns>`
Results in: 
`<th class="small-12 large-12 columns first last">
       <table>
         <tr>
           <th>One</th>
         </tr>
       </table>
  </th>`
Tweet: https://twitter.com/ZURBfoundation/status/717019195112689664
