### PR TITLE
Keep cheerio options alive in $.html()

### DIFF
--- a/lib/componentFactory.js
+++ b/lib/componentFactory.js
@@ -96,7 +96,7 @@ module.exports = function(element) {
 
       element.attr('data-parsed', '');
 
-      return format('', $.html(element, element.options));
+      return format('%s', $.html(element, element.options));
 
     // <callout>
     case this.components.callout:

--- a/lib/componentFactory.js
+++ b/lib/componentFactory.js
@@ -96,7 +96,7 @@ module.exports = function(element) {
 
       element.attr('data-parsed', '');
 
-      return format('%s', $.html(element));
+      return format('', $.html(element, element.options));
 
     // <callout>
     case this.components.callout:
@@ -131,6 +131,6 @@ module.exports = function(element) {
 
     default:
       // If it's not a custom component, return it as-is
-      return format('<tr><td>%s</td></tr>', $.html(element));
+      return format('<tr><td>%s</td></tr>', $.html(element, element.options));
   }
 }

--- a/test/inky.js
+++ b/test/inky.js
@@ -71,6 +71,13 @@ describe('Inky', () => {
     compare(input, expected, { decodeEntities: false });
   });
 
+  it(`doesn't decode entities if non default cheerio config is given in nested center elements`, () => {
+    var input = '<center>"should not replace quotes"</center>';
+    var expected = `<center data-parsed="">"should not replace quotes"</center>`;
+
+    compare(input, expected, { decodeEntities: false });
+  });
+
 });
 
 describe('Inky wrappers', () => {


### PR DESCRIPTION
see #25 

``$.html(element)`` loses the cheerio options that are passed in. Calling it with ``$.html(element, element.options)`` keeps them alive!

wdyt?