### PR TITLE
Allow multiple rows inside single table

### DIFF
--- a/lib/componentFactory.js
+++ b/lib/componentFactory.js
@@ -13,7 +13,29 @@ module.exports = function(element) {
     // <column>
     case this.components.columns:
       return this.makeColumn(element, 'columns');
+    
+    // <column2>  
+    case this.components.columns2:
+      return this.makeColumn2(element, 'columns2');
+    
+    // <innerrow>  
+    case this.components.innerrow:
+      var classes = ['innerrow'];
+      if (element.attr('class')) {
+        classes = classes.concat(element.attr('class').split(' '));
+      }
 
+      return format('<tr class="%s">%s</tr>', classes.join(' '), inner);
+
+    // <row2>
+    case this.components.row2:
+      var classes = ['row2'];
+      if (element.attr('class')) {
+        classes = classes.concat(element.attr('class').split(' '));
+      }
+
+      return format('<table class="%s"><tbody>%s</tbody></table>', classes.join(' '), inner);
+    
     // <row>
     case this.components.row:
       var classes = ['row'];

--- a/lib/inky.js
+++ b/lib/inky.js
@@ -23,8 +23,9 @@ function Inky(options) {
     menu: 'menu',
     menuItem: 'item',
     center: 'center',
-    spacer: 'spacer',
-    wrapper: 'wrapper'
+    columns2: 'columns2',
+    innerrow: 'innerrow',
+    row2: 'row2'
   }, options.components || {});
 
   // Column count for grid
@@ -62,3 +63,5 @@ Inky.prototype.releaseTheKraken = function($) {
 Inky.prototype.componentFactory = require('./componentFactory');
 
 Inky.prototype.makeColumn = require('./makeColumn');
+
+Inky.prototype.makeColumn2 = require('./makeColumn2');

--- a/lib/makeColumn2.js
+++ b/lib/makeColumn2.js
@@ -1,0 +1,57 @@
+var format = require('util').format;
+var multiline = require('multiline');
+var $ = require('cheerio');
+
+/**
+ * Returns output for column elements.
+ * @todo This could be refactored to handle both cols and subcols.
+ * @param {string} col - Column to format.
+ * @returns {string} Column HTML.
+ */
+module.exports = function(col) {
+  var output  = '';
+  var inner   = $(col).html();
+  var classes = [];
+  var expander = '';
+
+  // Add 1 to include current column
+  var colCount = $(col).siblings().length + 1;
+
+  // Inherit classes from the <column> tag
+  if ($(col).attr('class')) {
+    classes = classes.concat($(col).attr('class').split(' '));
+  }
+
+  // Check for sizes. If no attribute is provided, default to small-12. Divide evenly for large columns
+  var smallSize = $(col).attr('small') || this.columnCount;
+  var largeSize = $(col).attr('large') || $(col).attr('small') || Math.floor(this.columnCount / colCount);
+
+  classes.push(format('small-%s', smallSize));
+  classes.push(format('large-%s', largeSize));
+
+  // Add the basic "columns" class also
+  classes.push('columns');
+
+  // Determine if it's the first or last column, or both
+  if (!$(col).prev(this.components.columns).length) classes.push('first');
+  if (!$(col).next(this.components.columns).length) classes.push('last');
+
+  // If the column contains a nested row, the .expander class should not be used
+  // The == on the first check is because we're comparing a string pulled from $.attr() to a number
+  if (largeSize == this.columnCount && col.find('.innerrow, innerrow').length === 0) {
+    expander = '\n<th class="expander"></th>';
+  }
+
+  // Final HTML output
+  output = multiline(function() {/*
+    <th class="%s">
+      <table>
+        <tr>
+          <th>%s</th>%s
+        </tr>
+      </table>
+    </th>
+  */});
+
+  return format(output, classes.join(' '), inner, expander);
+}


### PR DESCRIPTION
Reduces impact of unintended spacing created between tables when message is forwarded.

Partially resolves https://github.com/zurb/foundation-emails/issues/308
And: http://stackoverflow.com/questions/36320051/outlook-adding-paragraph-after-every-table

Use case would work like this:
  ```
  <row2>
    <innerrow class="descriptive_table_header">
      <columns2 large="2">
        Product Name
      </columns2>
      <columns2 large="3">
        Price
      </columns2>
      <columns2 large="4">
        Shipping
      </columns2>
      <columns2 large="3">
        Date
      </columns2>
    </innerrow>
    <innerrow class="descriptive_fields">
      <columns2 large="2">
        Product A
      </columns2>
      <columns2 large="3">
        $20.00
      </columns2>
      <columns2 large="4">
        2 days
      </columns2>
      <columns2 large="3">
        Get it by Friday
      </columns2>
    </innerrow>
    <innerrow class="descriptive_fields">
      <columns2 large="2">
        Product B
      </columns2>
      <columns2 large="3">
        $50.00
      </columns2>
      <columns2 large="4">
        3 days
      </columns2>
      <columns2 large="3">
        Get it by Saturday
      </columns2>
    </innerrow>
  </row2>
```

Happy to answer any questions