### PR TITLE
Add missing tbody to several components (fix #58)

### DIFF
--- a/lib/componentFactory.js
+++ b/lib/componentFactory.js
@@ -52,7 +52,7 @@ module.exports = function(element) {
         classes = classes.concat(element.attr('class').split(' '));
       }
 
-      return format('<table class="%s"><tr><td><table><tr><td>%s</td></tr></table></td>%s</tr></table>', classes.join(' '), inner, expander);
+      return format('<table class="%s"><tbody><tr><td><table><tr><td>%s</td></tr></table></td>%s</tr></tbody></table>', classes.join(' '), inner, expander);
 
     // <container>
     case this.components.container:
@@ -73,7 +73,7 @@ module.exports = function(element) {
       if (element.attr('class')) {
         classes = classes.concat(element.attr('class').split(' '));
       }
-      return format('<table class="%s"><tr>%s</tr></table>', classes.join(' '), inner);
+      return format('<table class="%s"><tbody><tr>%s</tr></tbody></table>', classes.join(' '), inner);
 
     // <menu>
     case this.components.menu:
@@ -82,7 +82,7 @@ module.exports = function(element) {
         classes = classes.concat(element.attr('class').split(' '));
       }
       var centerAttr = element.attr('align') ? 'align="center"' : '';
-      return format('<table %s class="%s"%s><tr><td><table><tr>%s</tr></table></td></tr></table>', attrs, classes.join(' '), centerAttr, inner);
+      return format('<table %s class="%s"%s><tbody><tr><td><table><tbody><tr>%s</tr></tbody></table></td></tr></tbody></table>', attrs, classes.join(' '), centerAttr, inner);
 
     // <item>
     case this.components.menuItem:
@@ -118,7 +118,7 @@ module.exports = function(element) {
         classes = classes.concat(element.attr('class').split(' '));
       }
 
-      return format('<table %s class="callout"><tr><th class="%s">%s</th><th class="expander"></th></tr></table>', attrs, classes.join(' '), inner);
+      return format('<table %s class="callout"><tbody><tr><th class="%s">%s</th><th class="expander"></th></tr></tbody></table>', attrs, classes.join(' '), inner);
 
     // <spacer>
     case this.components.spacer:
@@ -155,7 +155,7 @@ module.exports = function(element) {
         classes = classes.concat(element.attr('class').split(' '));
       }
 
-      return format('<table %s class="%s" align="center"><tr><td class="wrapper-inner">%s</td></tr></table>', attrs, classes.join(' '), inner);
+      return format('<table %s class="%s" align="center"><tbody><tr><td class="wrapper-inner">%s</td></tr></tbody></table>', attrs, classes.join(' '), inner);
 
     default:
       // If it's not a custom component, return it as-is

--- a/lib/componentFactory.js
+++ b/lib/componentFactory.js
@@ -52,7 +52,7 @@ module.exports = function(element) {
         classes = classes.concat(element.attr('class').split(' '));
       }
 
-      return format('<table class="%s"><tbody><tr><td><table><tr><td>%s</td></tr></table></td>%s</tr></tbody></table>', classes.join(' '), inner, expander);
+      return format('<table class="%s"><tbody><tr><td><table><tbody><tr><td>%s</td></tr></tbody></table></td>%s</tr></tbody></table>', classes.join(' '), inner, expander);
 
     // <container>
     case this.components.container:

--- a/lib/makeColumn.js
+++ b/lib/makeColumn.js
@@ -50,9 +50,11 @@ module.exports = function(col) {
   output = multiline(function() {/*
     <th class="%s" %s>
       <table>
-        <tr>
-          <th>%s</th>%s
-        </tr>
+        <tbody>
+          <tr>
+            <th>%s</th>%s
+          </tr>
+        </tbody>
       </table>
     </th>
   */});

--- a/test/components.js
+++ b/test/components.js
@@ -46,17 +46,21 @@ describe('Center', () => {
     var expected = `
       <center data-parsed="">
         <table align="center" class="menu float-center">
-          <tr>
-            <td>
-              <table>
-                <tr>
-                  <th class="menu-item float-center">
-                    <a href="#"></a>
-                  </th>
-                </tr>
-              </table>
-            </td>
-          </tr>
+          <tbody>
+            <tr>
+              <td>
+                <table>
+                  <tbody>
+                    <tr>
+                      <th class="menu-item float-center">
+                        <a href="#"></a>
+                      </th>
+                    </tr>
+                  </tbody>
+                </table>
+              </td>
+            </tr>
+          </tbody>
         </table>
       </center>
     `;
@@ -70,15 +74,19 @@ describe('Button', () => {
     var input = '<button href="http://zurb.com">Button</button>';
     var expected = `
       <table class="button">
-        <tr>
-          <td>
-            <table>
-              <tr>
-                <td><a href="http://zurb.com">Button</a></td>
-              </tr>
-            </table>
-          </td>
-        </tr>
+        <tbody>
+          <tr>
+            <td>
+              <table>
+                <tbody>
+                  <tr>
+                    <td><a href="http://zurb.com">Button</a></td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+        </tbody>
       </table>
     `;
 
@@ -89,15 +97,19 @@ describe('Button', () => {
     var input = '<button href="http://zurb.com" target="_blank">Button</button>';
     var expected = `
       <table class="button">
-        <tr>
-          <td>
-            <table>
-              <tr>
-                <td><a href="http://zurb.com" target="_blank">Button</a></td>
-              </tr>
-            </table>
-          </td>
-        </tr>
+        <tbody>
+          <tr>
+            <td>
+              <table>
+                <tbody>
+                  <tr>
+                    <td><a href="http://zurb.com" target="_blank">Button</a></td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+        </tbody>
       </table>
     `;
 
@@ -110,15 +122,19 @@ describe('Button', () => {
     `;
     var expected = `
       <table class="button small alert">
-        <tr>
-          <td>
-            <table>
-              <tr>
-                <td><a href="http://zurb.com">Button</a></td>
-              </tr>
-            </table>
-          </td>
-        </tr>
+        <tbody>
+          <tr>
+            <td>
+              <table>
+                <tbody>
+                  <tr>
+                    <td><a href="http://zurb.com">Button</a></td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+        </tbody>
       </table>
     `;
 
@@ -131,18 +147,22 @@ describe('Button', () => {
     `;
     var expected = `
       <table class="button expand">
-        <tr>
-          <td>
-            <table>
-              <tr>
-                <td>
-                  <center data-parsed=""><a href="http://zurb.com" align="center" class="float-center">Button</a></center>
-                </td>
-              </tr>
-            </table>
-          </td>
-          <td class="expander"></td>
-        </tr>
+        <tbody>
+          <tr>
+            <td>
+              <table>
+                <tbody>
+                  <tr>
+                    <td>
+                      <center data-parsed=""><a href="http://zurb.com" align="center" class="float-center">Button</a></center>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+            <td class="expander"></td>
+          </tr>
+        </tbody>
       </table>
     `;
 
@@ -159,15 +179,19 @@ describe('Menu', () => {
     `;
     var expected = `
       <table class="menu">
-        <tr>
-          <td>
-            <table>
-              <tr>
-                <th class="menu-item"><a href="http://zurb.com">Item</a></th>
-              </tr>
-            </table>
-          </td>
-        </tr>
+        <tbody>
+          <tr>
+            <td>
+              <table>
+                <tbody>
+                  <tr>
+                    <th class="menu-item"><a href="http://zurb.com">Item</a></th>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+        </tbody>
       </table>
     `;
 
@@ -182,15 +206,19 @@ describe('Menu', () => {
     `;
     var expected = `
       <table class="menu">
-        <tr>
-          <td>
-            <table>
-              <tr>
-                <th class="menu-item"><a href="http://zurb.com" target="_blank">Item</a></th>
-              </tr>
-            </table>
-          </td>
-        </tr>
+        <tbody>
+          <tr>
+            <td>
+              <table>
+                <tbody>
+                  <tr>
+                    <th class="menu-item"><a href="http://zurb.com" target="_blank">Item</a></th>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+        </tbody>
       </table>
     `;
 
@@ -204,14 +232,18 @@ describe('Menu', () => {
     `;
     var expected = `
       <table class="menu vertical">
-        <tr>
-          <td>
-            <table>
-              <tr>
-              </tr>
-            </table>
-          </td>
-        </tr>
+        <tbody>
+          <tr>
+            <td>
+              <table>
+                <tbody>
+                  <tr>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+        </tbody>
       </table>
     `;
 
@@ -226,15 +258,19 @@ describe('Menu', () => {
     `;
     var expected = `
       <table class="menu">
-        <tr>
-          <td>
-            <table>
-              <tr>
-                <th class="menu-item"><a href="http://zurb.com">Item 1</a></th>
-              </tr>
-            </table>
-          </td>
-        </tr>
+        <tbody>
+          <tr>
+            <td>
+              <table>
+                <tbody>
+                  <tr>
+                    <th class="menu-item"><a href="http://zurb.com">Item 1</a></th>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+        </tbody>
       </table>
     `;
 
@@ -247,10 +283,12 @@ describe('Callout', () => {
     var input = '<callout>Callout</callout>';
     var expected = `
       <table class="callout">
-        <tr>
-          <th class="callout-inner">Callout</th>
-          <th class="expander"></th>
-        </tr>
+        <tbody>
+          <tr>
+            <th class="callout-inner">Callout</th>
+            <th class="expander"></th>
+          </tr>
+        </tbody>
       </table>
     `;
 
@@ -261,10 +299,12 @@ describe('Callout', () => {
     var input = '<callout class="primary">Callout</callout>';
     var expected = `
       <table class="callout">
-        <tr>
-          <th class="callout-inner primary">Callout</th>
-          <th class="expander"></th>
-        </tr>
+        <tbody>
+          <tr>
+            <th class="callout-inner primary">Callout</th>
+            <th class="expander"></th>
+          </tr>
+        </tbody>
       </table>
     `;
 
@@ -361,9 +401,11 @@ describe('wrapper', () => {
     var input = `<wrapper class="header"></wrapper>`;
     var expected = `
       <table class="wrapper header" align="center">
-        <tr>
-          <td class="wrapper-inner"></td>
-        </tr>
+        <tbody>
+          <tr>
+            <td class="wrapper-inner"></td>
+          </tr>
+        </tbody>
       </table>
     `;
 

--- a/test/grid.js
+++ b/test/grid.js
@@ -64,10 +64,12 @@ describe('Grid', () => {
     var expected = `
       <th class="small-12 large-12 columns first last">
         <table>
-          <tr>
-            <th>One</th>
-            <th class="expander"></th>
-          </tr>
+          <tbody>
+            <tr>
+              <th>One</th>
+              <th class="expander"></th>
+            </tr>
+          </tbody>
         </table>
       </th>
     `;
@@ -80,9 +82,11 @@ describe('Grid', () => {
     var expected = `
       <th class="small-12 large-12 columns first last">
         <table>
-          <tr>
-            <th>One</th>
-          </tr>
+          <tbody>
+            <tr>
+              <th>One</th>
+            </tr>
+          </tbody>
         </table>
       </th>
     `;
@@ -95,10 +99,12 @@ describe('Grid', () => {
     var expected = `
       <th class="small-12 large-12 columns first last">
         <table>
-          <tr>
-            <th>One</th>
-            <th class="expander"></th>
-          </tr>
+          <tbody>
+            <tr>
+              <th>One</th>
+              <th class="expander"></th>
+            </tr>
+          </tbody>
         </table>
       </th>
     `;
@@ -111,9 +117,11 @@ describe('Grid', () => {
     var expected = `
       <th class="small-12 large-12 columns first last">
         <table>
-          <tr>
-            <th>One</th>
-          </tr>
+          <tbody>
+            <tr>
+              <th>One</th>
+            </tr>
+          </tbody>
         </table>
       </th>
     `;
@@ -129,16 +137,20 @@ describe('Grid', () => {
     var expected = `
       <th class="small-12 large-6 columns first">
         <table>
-          <tr>
-            <th>One</th>
-          </tr>
+          <tbody>
+            <tr>
+              <th>One</th>
+            </tr>
+          </tbody>
         </table>
       </th>
       <th class="small-12 large-6 columns last">
         <table>
-          <tr>
-            <th>Two</th>
-          </tr>
+          <tbody>
+            <tr>
+              <th>Two</th>
+            </tr>
+          </tbody>
         </table>
       </th>
     `;
@@ -155,23 +167,29 @@ describe('Grid', () => {
     var expected = `
       <th class="small-12 large-4 columns first">
         <table>
-          <tr>
-            <th>One</th>
-          </tr>
+          <tbody>
+            <tr>
+              <th>One</th>
+            </tr>
+          </tbody>
         </table>
       </th>
       <th class="small-12 large-4 columns">
         <table>
-          <tr>
-            <th>Two</th>
-          </tr>
+          <tbody>
+            <tr>
+              <th>Two</th>
+            </tr>
+          </tbody>
         </table>
       </th>
       <th class="small-12 large-4 columns last">
         <table>
-          <tr>
-            <th>Three</th>
-          </tr>
+          <tbody>
+            <tr>
+              <th>Three</th>
+            </tr>
+          </tbody>
         </table>
       </th>
     `;
@@ -184,10 +202,12 @@ describe('Grid', () => {
     var expected = `
       <th class="small-offset-8 hide-for-small small-12 large-12 columns first last">
         <table>
-          <tr>
-            <th>One</th>
-            <th class="expander"></th>
-          </tr>
+          <tbody>
+            <tr>
+              <th>One</th>
+              <th class="expander"></th>
+            </tr>
+          </tbody>
         </table>
       </th>
     `;
@@ -204,16 +224,20 @@ describe('Grid', () => {
     var expected = `
       <th class="small-4 large-4 columns first">
         <table>
-          <tr>
-            <th>One</th>
-          </tr>
+          <tbody>
+            <tr>
+              <th>One</th>
+            </tr>
+          </tbody>
         </table>
       </th>
       <th class="small-8 large-8 columns last">
         <table>
-          <tr>
-            <th>Two</th>
-          </tr>
+          <tbody>
+            <tr>
+              <th>Two</th>
+            </tr>
+          </tbody>
         </table>
       </th>
     `;
@@ -229,16 +253,20 @@ describe('Grid', () => {
     var expected = `
       <th class="small-12 large-4 columns first">
         <table>
-          <tr>
-            <th>One</th>
-          </tr>
+          <tbody>
+            <tr>
+              <th>One</th>
+            </tr>
+          </tbody>
         </table>
       </th>
       <th class="small-12 large-8 columns last">
         <table>
-          <tr>
-            <th>Two</th>
-          </tr>
+          <tbody>
+            <tr>
+              <th>Two</th>
+            </tr>
+          </tbody>
         </table>
       </th>
     `;
@@ -254,15 +282,17 @@ describe('Grid', () => {
           <tr>
             <th class="small-12 large-12 columns first last">
               <table>
-                <tr>
-                  <th>
-                    <table class="row">
-                      <tbody>
-                        <tr></tr>
-                      </tbody>
-                    </table>
-                  </th>
-                </tr>
+                <tbody>
+                  <tr>
+                    <th>
+                      <table class="row">
+                        <tbody>
+                          <tr></tr>
+                        </tbody>
+                      </table>
+                    </th>
+                  </tr>
+                </tbody>
               </table>
             </th>
           </tr>
@@ -281,10 +311,12 @@ describe('Grid', () => {
           <tr>
             <th class="small-12 large-12 columns first last" dir="rtl" valign="middle" align="center">
               <table>
-                <tr>
-                  <th>One</th>
-                  <th class="expander"></th>
-                </tr>
+                <tbody>
+                  <tr>
+                    <th>One</th>
+                    <th class="expander"></th>
+                  </tr>
+                </tbody>
               </table>
             </th>
           </tr>
@@ -301,7 +333,9 @@ describe('Block Grid', () => {
     var input = '<block-grid up="4"></block-grid>';
     var expected = `
       <table class="block-grid up-4">
-        <tr></tr>
+        <tbody>
+          <tr></tr>
+        </tbody>
       </table>
     `;
 
@@ -312,7 +346,9 @@ describe('Block Grid', () => {
     var input = '<block-grid up="4" class="show-for-large"></block-grid>';
     var expected = `
       <table class="block-grid up-4 show-for-large">
-        <tr></tr>
+        <tbody>
+          <tr></tr>
+        </tbody>
       </table>
     `;
 


### PR DESCRIPTION
Rendering the HTML output inside a `react` component would throw a warning.

```
warning.js?8a56:44 Warning: validateDOMNesting(...): <tr> cannot appear as a child of <table>. See StatelessComponent > table > tr. Add a <tbody> to your code to match the DOM tree generated by the browser.
```
