### PR TITLE
Allow to add attributes to buttons and spacers

### DIFF
--- a/lib/componentFactory.js
+++ b/lib/componentFactory.js
@@ -131,11 +131,11 @@ module.exports = function(element) {
       if (element.attr('size-sm') || element.attr('size-lg')) {
         if (element.attr('size-sm')) {
           size = (element.attr('size-sm'));
-          html += '<table %s class="%s hide-for-large"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&#xA0;</td></tr></tbody></table>';
+          html += format('<table %s class="%s hide-for-large"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&#xA0;</td></tr></tbody></table>', attrs);
         }
         if (element.attr('size-lg')) {
           size = (element.attr('size-lg'));
-          html += '<table %s class="%s show-for-large"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&#xA0;</td></tr></tbody></table>';
+          html += format('<table %s class="%s show-for-large"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&#xA0;</td></tr></tbody></table>', attrs);
         }
       } else {
         size = (element.attr('size')) || 16;
@@ -143,7 +143,7 @@ module.exports = function(element) {
       }
 
       if( element.attr('size-sm') && element.attr('size-lg') ) {
-        return format(html, attrs, classes.join(' '), classes.join(' '), inner);
+        return format(html, classes.join(' '), classes.join(' '), inner);
       }
 
       return format(html, attrs, classes.join(' '), inner);

--- a/lib/componentFactory.js
+++ b/lib/componentFactory.js
@@ -139,14 +139,14 @@ module.exports = function(element) {
         }
       } else {
         size = (element.attr('size')) || 16;
-        html += '<table %s class="%s"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&#xA0;</td></tr></tbody></table>';
+        html += format('<table %s class="%s"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&#xA0;</td></tr></tbody></table>', attrs);
       }
 
       if( element.attr('size-sm') && element.attr('size-lg') ) {
         return format(html, classes.join(' '), classes.join(' '), inner);
       }
 
-      return format(html, attrs, classes.join(' '), inner);
+      return format(html, classes.join(' '), inner);
 
     // <wrapper>
     case this.components.wrapper:

--- a/lib/componentFactory.js
+++ b/lib/componentFactory.js
@@ -37,7 +37,7 @@ module.exports = function(element) {
 
       // If we have the href attribute we can create an anchor for the inner of the button;
       if (element.attr('href')) {
-        inner = format('<a href="%s"%s>%s</a>', element.attr('href'), target, inner);
+        inner = format('<a %s href="%s"%s>%s</a>', attrs, element.attr('href'), target, inner);
       }
 
       // If the button is expanded, it needs a <center> tag around the content

--- a/lib/componentFactory.js
+++ b/lib/componentFactory.js
@@ -131,22 +131,22 @@ module.exports = function(element) {
       if (element.attr('size-sm') || element.attr('size-lg')) {
         if (element.attr('size-sm')) {
           size = (element.attr('size-sm'));
-          html += '<table class="%s hide-for-large"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&#xA0;</td></tr></tbody></table>';
+          html += '<table %s class="%s hide-for-large"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&#xA0;</td></tr></tbody></table>';
         }
         if (element.attr('size-lg')) {
           size = (element.attr('size-lg'));
-          html += '<table class="%s show-for-large"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&#xA0;</td></tr></tbody></table>';
+          html += '<table %s class="%s show-for-large"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&#xA0;</td></tr></tbody></table>';
         }
       } else {
         size = (element.attr('size')) || 16;
-        html += '<table class="%s"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&#xA0;</td></tr></tbody></table>';
+        html += '<table %s class="%s"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&#xA0;</td></tr></tbody></table>';
       }
 
       if( element.attr('size-sm') && element.attr('size-lg') ) {
-        return format(html, classes.join(' '), classes.join(' '), inner);
+        return format(html, attrs, classes.join(' '), classes.join(' '), inner);
       }
 
-      return format(html, classes.join(' '), inner);
+      return format(html, attrs, classes.join(' '), inner);
 
     // <wrapper>
     case this.components.wrapper:

--- a/lib/util/getAttrs.js
+++ b/lib/util/getAttrs.js
@@ -3,7 +3,7 @@
 // @returns {string} attributes pulled from inky objects
 module.exports = function(el) {
 	var attrs = el.attr();
-    var ignoredAttributes = ['class', 'id', 'href', 'size', 'large', 'no-expander', 'small', 'target'];
+    var ignoredAttributes = ['class', 'id', 'href', 'size', 'size-sm', 'size-lg', 'large', 'no-expander', 'small', 'target'];
     var result = '';
 
     for (var key in attrs) {


### PR DESCRIPTION
This would be useful if we are adding attributes that help us to integrate the HTML with some WYSIWYG (as Mailchimp with mc:edit). Most of the existing components keep the attributes, but not the button.

I think the right place to put the attributes should be the <a> element, as everything surrounding the link is just a helper for the link to show nicely.

