### PR TITLE
Remove counter productive code

### DIFF
--- a/lib/componentFactory.js
+++ b/lib/componentFactory.js
@@ -81,8 +81,7 @@ module.exports = function(element) {
       if (element.attr('class')) {
         classes = classes.concat(element.attr('class').split(' '));
       }
-      var centerAttr = element.attr('align') ? 'align="center"' : '';
-      return format('<table %s class="%s"%s><tr><td><table><tr>%s</tr></table></td></tr></table>', attrs, classes.join(' '), centerAttr, inner);
+      return format('<table %s class="%s"><tr><td><table><tr>%s</tr></table></td></tr></table>', attrs, classes.join(' '), inner);
 
     // <item>
     case this.components.menuItem:


### PR DESCRIPTION
Any existing attribute `'align'` is already present in `attrs`.

Or am I missing something?

Also, if I'm not mistaken, if there is an `align` specified, say for a `<wrapper>`, then the lib nevertheless adds a `align="center"` and relies on `cheerio` to remove it as it is a duplicated attribute. Is that right?
