### PR TITLE
Switch <spacer>'s non-breaking spaces from &#xA0; to &nbsp;

### DIFF
--- a/lib/componentFactory.js
+++ b/lib/componentFactory.js
@@ -139,15 +139,15 @@ module.exports = function(element) {
       if (element.attr('size-sm') || element.attr('size-lg')) {
         if (element.attr('size-sm')) {
           size = (element.attr('size-sm'));
-          html += format('<table %s class="%s hide-for-large"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&#xA0;</td></tr></tbody></table>', attrs);
+          html += format('<table %s class="%s hide-for-large"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&nbsp;</td></tr></tbody></table>', attrs);
         }
         if (element.attr('size-lg')) {
           size = (element.attr('size-lg'));
-          html += format('<table %s class="%s show-for-large"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&#xA0;</td></tr></tbody></table>', attrs);
+          html += format('<table %s class="%s show-for-large"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&nbsp;</td></tr></tbody></table>', attrs);
         }
       } else {
         size = (element.attr('size')) || 16;
-        html += format('<table %s class="%s"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&#xA0;</td></tr></tbody></table>', attrs);
+        html += format('<table %s class="%s"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&nbsp;</td></tr></tbody></table>', attrs);
       }
 
       if( element.attr('size-sm') && element.attr('size-lg') ) {

--- a/test/components.js
+++ b/test/components.js
@@ -279,7 +279,7 @@ describe('Spacer', () => {
       <table class="spacer">
         <tbody>
           <tr>
-            <td height="10px" style="font-size:10px;line-height:10px;">&#xA0;</td>
+            <td height="10px" style="font-size:10px;line-height:10px;">&nbsp;</td>
           </tr>
         </tbody>
       </table>
@@ -295,7 +295,7 @@ describe('Spacer', () => {
       <table class="spacer">
         <tbody>
           <tr>
-            <td height="16px" style="font-size:16px;line-height:16px;">&#xA0;</td>
+            <td height="16px" style="font-size:16px;line-height:16px;">&nbsp;</td>
           </tr>
         </tbody>
       </table>
@@ -310,7 +310,7 @@ describe('Spacer', () => {
       <table class="spacer hide-for-large">
         <tbody>
           <tr>
-            <td height="10px" style="font-size:10px;line-height:10px;">&#xA0;</td>
+            <td height="10px" style="font-size:10px;line-height:10px;">&nbsp;</td>
           </tr>
         </tbody>
       </table>
@@ -325,7 +325,7 @@ describe('Spacer', () => {
       <table class="spacer show-for-large">
         <tbody>
           <tr>
-            <td height="20px" style="font-size:20px;line-height:20px;">&#xA0;</td>
+            <td height="20px" style="font-size:20px;line-height:20px;">&nbsp;</td>
           </tr>
         </tbody>
       </table>
@@ -340,14 +340,14 @@ describe('Spacer', () => {
       <table class="spacer hide-for-large">
         <tbody>
           <tr>
-            <td height="10px" style="font-size:10px;line-height:10px;">&#xA0;</td>
+            <td height="10px" style="font-size:10px;line-height:10px;">&nbsp;</td>
           </tr>
         </tbody>
       </table>
       <table class="spacer show-for-large">
         <tbody>
           <tr>
-            <td height="20px" style="font-size:20px;line-height:20px;">&#xA0;</td>
+            <td height="20px" style="font-size:20px;line-height:20px;">&nbsp;</td>
           </tr>
         </tbody>
       </table>
@@ -362,7 +362,7 @@ describe('Spacer', () => {
       <table class="spacer bgcolor">
         <tbody>
           <tr>
-            <td height="10px" style="font-size:10px;line-height:10px;">&#xA0;</td>
+            <td height="10px" style="font-size:10px;line-height:10px;">&nbsp;</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
The character `&#xA0;` is being rendered as a space on Apple Mail's _preview_ (tested on 9 and 10). Switching it to a regular `&nbsp;` seems to sort the issue.

Attempts to fix #69.