### PR TITLE
Update componentFactory.js

### DIFF
--- a/lib/componentFactory.js
+++ b/lib/componentFactory.js
@@ -23,7 +23,7 @@ module.exports = function(element) {
         classes = classes.concat(element.attr('class').split(' '));
       }
 
-      return format('<table %s class="%s"><tbody><tr>%s</tr></tbody></table>', attrs, classes.join(' '), inner);
+      return format('<table %s class="%s"><tbody><tr>%s</tr></tbody></table>&zwj;', attrs, classes.join(' '), inner);
 
     // <button>
     case this.components.button:


### PR DESCRIPTION
Fix gap issue in Outlook 2016 referred to in http://foundation.zurb.com/forum/posts/50493-rows-and-spacers--outlook-trouble
This fix has been retested from a clean install.
Before fix (not the background has been made black so the issue can be seen)
![image](https://cloud.githubusercontent.com/assets/1550530/22718102/5e894e90-ee03-11e6-9a94-243146c86568.png)

After:
![image](https://cloud.githubusercontent.com/assets/1550530/22718117/7ee35802-ee03-11e6-9ed4-f1facb2a904e.png)


