### PR TITLE
Attributes for inner link in `button` and `menu-item`

### DIFF
--- a/lib/componentFactory.js
+++ b/lib/componentFactory.js
@@ -45,11 +45,11 @@ module.exports = function(element) {
 
       // If we have the href attribute we can create an anchor for the inner of the button;
       if (element.attr('href')) {
-        // support for Sendgrid's clicktracking="off" attribute
-        var hrefAttrs = '';
-        if (element.attr('href-clicktracking')) {
-          hrefAttrs = format('clicktracking="%s"', element.attr('href-clicktracking'));
-        }
+        // support for all types of href- attributes for inner link (e.g. Sendgrid's clicktracking="off")
+        var hrefAttrs = attrs.split(' ')
+                          .filter(attr => attr.startsWith('href-'))
+                          .map(attr => ' '+attr.replace('href-',''))
+                          .join();
         inner = format('<a %s href="%s"%s>%s</a>', hrefAttrs, element.attr('href'), target, inner);
       }
 
@@ -107,11 +107,11 @@ module.exports = function(element) {
       if (element.attr('class')) {
         classes = classes.concat(element.attr('class').split(' '));
       }
-      // support for Sendgrid's clicktracking="off" attribute
-      var hrefAttrs = '';
-      if (element.attr('href-clicktracking')) {
-        hrefAttrs = format('clicktracking="%s"', element.attr('href-clicktracking'));
-      }
+      // support for all types of href- attributes for inner link (e.g. Sendgrid's clicktracking="off")
+      var hrefAttrs = attrs.split(' ')
+                          .filter(attr => attr.startsWith('href-'))
+                          .map(attr => ' '+attr.replace('href-',''))
+                          .join();
       return format('<th %s class="%s"><a %s href="%s"%s>%s</a></th>', attrs, classes.join(' '), hrefAttrs, element.attr('href'), target, inner);
 
     // <center>

--- a/lib/componentFactory.js
+++ b/lib/componentFactory.js
@@ -45,7 +45,12 @@ module.exports = function(element) {
 
       // If we have the href attribute we can create an anchor for the inner of the button;
       if (element.attr('href')) {
-        inner = format('<a %s href="%s"%s>%s</a>', attrs, element.attr('href'), target, inner);
+        // support for Sendgrid's clicktracking="off" attribute
+        var hrefAttrs = '';
+        if (element.attr('href-clicktracking')) {
+          hrefAttrs = format('clicktracking="%s"', element.attr('href-clicktracking'));
+        }
+        inner = format('<a %s href="%s"%s>%s</a>', hrefAttrs, element.attr('href'), target, inner);
       }
 
       // If the button is expanded, it needs a <center> tag around the content
@@ -102,7 +107,12 @@ module.exports = function(element) {
       if (element.attr('class')) {
         classes = classes.concat(element.attr('class').split(' '));
       }
-      return format('<th %s class="%s"><a href="%s"%s>%s</a></th>', attrs, classes.join(' '), element.attr('href'), target, inner);
+      // support for Sendgrid's clicktracking="off" attribute
+      var hrefAttrs = '';
+      if (element.attr('href-clicktracking')) {
+        hrefAttrs = format('clicktracking="%s"', element.attr('href-clicktracking'));
+      }
+      return format('<th %s class="%s"><a %s href="%s"%s>%s</a></th>', attrs, classes.join(' '), hrefAttrs, element.attr('href'), target, inner);
 
     // <center>
     case this.components.center:


### PR DESCRIPTION
To enable attributes directly on inner `<a href=""></a>` of `button` and `menu-item` we can transfer parent's element attributes that start with `href-`.  E.g.  `<button href-clicktracking="off" href="https://my.domain.com">...</button>` 
after processing will contain `...<a clicktracking="off" href="https://my.domain.com">...</a>...`

This enables usage of custom attributes like  Sendgrid's `clicktracking="off"`.